### PR TITLE
Fix /relations to work when not caching

### DIFF
--- a/korp.py
+++ b/korp.py
@@ -2776,8 +2776,8 @@ def relations(args):
                 pass
 
     for row in itertools.chain(relations_data, (None,), cursor_result):
-        if row is None and args["cache"]:
-            do_caching = True
+        if row is None:
+            do_caching = args["cache"]
             continue
 
         if do_caching:


### PR DESCRIPTION
Fix `/relations` to work with `cache=false` or if caching is not configured, fixing e.g. https://ws.spraakbanken.gu.se/ws/korp/v8/relations?word=ge..vb.1&type=lemgram&corpus=ROMI&indent=4&cache=false to return the same value as https://ws.spraakbanken.gu.se/ws/korp/v8/relations?word=ge..vb.1&type=lemgram&corpus=ROMI&indent=4, instead of the error

    {
        "ERROR": {
            "type": "TypeError",
            "value": "'NoneType' object is not subscriptable"
        },
        "time": 0.16933250427246094
    }