### PR TITLE
Pytest testing support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ venv/
 
 # Instance dir
 instance/
+
+# Coverage.py
+.coverage
+*,cover

--- a/README.md
+++ b/README.md
@@ -63,9 +63,11 @@ Optionally you may set up a virtual Python environment:
     $ python3 -m venv venv
     $ source venv/bin/activate
 
-Install the required Python modules using `pip` with the included requirements.txt.
+Install the required Python modules using `pip` with the included `requirements.txt`.
 
     $ pip3 install -r requirements.txt
+
+If you wish to be able to run tests (useful mainly for Korp developers), install from `requirements-dev.txt` instead of `requirements.txt`.
 
 
 ## Configuring Korp

--- a/korp/__init__.py
+++ b/korp/__init__.py
@@ -14,7 +14,7 @@ from korp.memcached import memcached
 __version__ = "8.2.5"
 
 
-def create_app():
+def create_app(config_override=None):
     """Application factory, creating and configuring the Flask app."""
 
     app = Flask(__name__)
@@ -31,6 +31,9 @@ def create_app():
         app.config.from_pyfile(str(instance_config_path))
     else:
         print(f"Configure Korp by copying config.py to '{app.instance_path}' and modifying that copy")
+
+    if config_override is not None:
+        app.config.update(config_override)
 
     cwb.init(
         executable=app.config["CQP_EXECUTABLE"],

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,12 @@
+# Common requirements
+-r requirements.txt
+
+# Requirements for development
+
+coverage~=7.0
+pytest~=7.2
+# To use FlaskClient used in testing, Werkzeug version needs to be
+# lower than 2.1 for Flask version lower than 2.1 (see
+# https://stackoverflow.com/q/71661851). The other option would be to
+# upgrade Flask to 2.1.*.
+werkzeug~=2.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-coverage~=7.0
 Flask==2.0.2
 Flask-Cors==3.0.10
 Flask-MySQLdb==0.2.0
@@ -6,11 +5,5 @@ mysqlclient==1.3.13
 gevent==21.12.0
 psutil==5.9.3
 pymemcache==4.0.0
-pytest~=7.2
 python-dateutil==2.8.2
 PyYAML==6.0
-# To use FlaskClient (used in testing), Werkzeug version needs to be
-# lower than 2.1 for Flask version lower than 2.1 (see
-# https://stackoverflow.com/q/71661851). The other option would be to
-# upgrade Flask to 2.1.*.
-werkzeug~=2.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+coverage~=7.0
 Flask==2.0.2
 Flask-Cors==3.0.10
 Flask-MySQLdb==0.2.0
@@ -5,6 +6,7 @@ mysqlclient==1.3.13
 gevent==21.12.0
 psutil==5.9.3
 pymemcache==4.0.0
+pytest~=7.2
 python-dateutil==2.8.2
 PyYAML==6.0
 # To use FlaskClient (used in testing), Werkzeug version needs to be

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,8 @@ psutil==5.9.3
 pymemcache==4.0.0
 python-dateutil==2.8.2
 PyYAML==6.0
+# To use FlaskClient (used in testing), Werkzeug version needs to be
+# lower than 2.1 for Flask version lower than 2.1 (see
+# https://stackoverflow.com/q/71661851). The other option would be to
+# upgrade Flask to 2.1.*.
+werkzeug~=2.0.3

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,152 @@
+
+# Tests for the Korp backend
+
+This directory `tests` contains [Pytest](https://pytest.org) tests for
+the Korp backend.
+
+
+## Prerequisites
+
+To be able to run tests, you need to install the development
+requirements by running
+```
+$ pip3 install -r requirements-dev.txt
+```
+
+In addition, you need to have the Corpus Workbench (CWB), in
+particular `cwb-encode`, and the CWB Perl tools (for `cwb-make`),
+installed and on `PATH` (see the [main README
+file](../README.md#corpus-workbench)). The CWB Perl tools can be
+installed from the CWB Subversion repository at
+http://svn.code.sf.net/p/cwb/code/perl/trunk
+
+
+## Running tests
+
+To run tests, run
+```
+$ pytest
+```
+
+To find out test coverage using
+[Coverage.py](https://coverage.readthedocs.io/), run
+```
+$ coverage -m pytest
+```
+and then, for example,
+```
+$ coverage report
+```
+
+
+## Directory Layout
+
+This directory `tests/` contains:
+
+- [`unit/`](unit): unit tests, typically testing functions in modules
+  directly under the `korp` package
+- [`functional/`](functional): functional tests, typically testing the endpoints
+  (`korp.views.*`)
+- `data/`: test data
+  - [`data/corpora/src`](data/corpora/src): corpus source data
+- [`conftest.py`](conftest.py): Pytest configuration; in particular,
+  fixtures to be used by individual tests
+- [`corpusutils.py`](corpusutils.py): utility functions for setting up
+  CWB corpus data
+
+
+## Adding tests
+
+Individual test files and tests should follow Pytest conventions: the
+names of files containing tests should begin with `test_`, as should
+also the names of test functions and methods. Tests can be grouped in
+classes whose names begin with `Test`.
+
+
+### Fixtures
+
+The following Pytest fixtures have been defined in
+[`conftest.py`](conftest.py):
+
+- `corpus_data_root`: Return CWB corpus root directory for a session
+- `corpus_registry_dir`: Return CWB corpus registry directory for a session
+- `corpora`: Encode the corpora in `data/corpora/src` and return their ids
+- `app`: Create and configure a Korp Flask app instance
+- `client`: Create and return a test client
+
+
+### Functional tests
+
+A typical functional test testing an endpoint uses the `client` and
+`corpora` fixtures. For example:
+
+```python
+def test_corpus_info_single_corpus(self, client, corpora):
+    corpus = corpora[0].upper()
+    response = client.get(
+        "/corpus_info",
+        query_string={
+            "cache": "false",
+            "corpus": corpus,
+        })
+    assert response.status_code == 200
+    assert response.is_json == True
+    data = response.get_json()
+    corpus_data = data["corpora"][corpus]
+    attrs = corpus_data["attrs"]
+    assert attrs
+```
+
+
+### Corpus data
+
+Each CWB corpus _corpus_ whose data is used in the tests should have a
+source VRT file _corpus_`.vrt` in `data/corpora/src`. The corpus
+source files use a slightly extended VRT (VeRticalized Text) format
+(the input format for CWB), where structures are marked with XML-style
+tags (with attributes) and each token is on its own line, token
+attributes separated by tags.
+
+The extension is that the positional and structural attributes need to
+be declared at the top of the file as XML comments as follows:
+```
+<!-- #vrt positional-attributes: attr1 attr2 ... -->
+<!-- #vrt structural-attributes: text:0+a1+a2 sentence:0+a3+a4 ... -->
+```
+For example:
+```
+<!-- #vrt positional-attributes: word lemma -->
+<!-- #vrt structural-attributes: text:0+id paragraph:0+id sentence:0+id -->
+<text id="t1">
+<paragraph id="p1">
+<sentence id="s1">
+</sentence>
+This	this
+is	be
+a	a
+test	test
+.	.
+<sentence id="s2">
+Great	great
+!	!
+</sentence>
+</paragraph>
+</text>
+```
+
+In addition to the VRT file _corpus_`.vrt`, a corpus should have a
+corresponding info file _corpus_`.info` containing at least the number
+of sentences and date of update in the ISO format as follows:
+```
+Sentences: 2
+Updated: 2023-01-20
+```
+
+Note that the encoded test corpus data is placed under a temporary
+directory for the duration of a test session, so test corpora are
+isolated from any other CWB corpora in the system.
+
+
+### Database data
+
+_[To be added when database testing is implemented.]_

--- a/tests/README.md
+++ b/tests/README.md
@@ -53,6 +53,8 @@ This directory `tests/` contains:
   fixtures to be used by individual tests
 - [`corpusutils.py`](corpusutils.py): utility functions for setting up
   CWB corpus data
+- [`testutils.py`](testutils.py): utility functions for tests, typically
+  functionality that recur in multiple tests but that cannot be made fixtures
 
 
 ## Adding tests

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+# tests/__init__.py
+#
+# This file makes tests a package, to make pytest work directly and
+# not only "python -m pytest".

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,11 @@ from korp import create_app
 from tests.corpusutils import CWBEncoder
 
 
+# Functions in tests.utils are called by tests and contain assertions
+# that should be rewritten
+pytest.register_assert_rewrite("tests.testutils")
+
+
 @pytest.fixture(scope="session")
 def corpus_data_root(tmp_path_factory):
     """Return a corpus data root directory for a session."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ import pytest
 from pathlib import Path
 
 from korp import create_app
+from tests.corpusutils import CWBEncoder
 
 
 @pytest.fixture(scope="session")
@@ -41,3 +42,11 @@ def app(corpus_registry_dir):
 def client(app):
     """Create and return a test client."""
     return app.test_client()
+
+
+@pytest.fixture(scope="session")
+def corpora(corpus_data_root):
+    """Encode corpora in data/corpora/src and return their corpus ids."""
+    corpus_source_dir = Path(__file__).parent / "data" / "corpora" / "src"
+    cwb_encoder = CWBEncoder(str(corpus_data_root))
+    return cwb_encoder.encode_corpora(str(corpus_source_dir))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,15 +8,30 @@ Pytest fixtures for testing the Korp backend as a Flask app.
 
 import pytest
 
+from pathlib import Path
+
 from korp import create_app
 
 
+@pytest.fixture(scope="session")
+def corpus_data_root(tmp_path_factory):
+    """Return a corpus data root directory for a session."""
+    return tmp_path_factory.mktemp("corpora")
+
+
+@pytest.fixture(scope="session")
+def corpus_registry_dir(corpus_data_root):
+    """Return a corpus registry directory for a session."""
+    return str(corpus_data_root / "registry")
+
+
 @pytest.fixture()
-def app():
+def app(corpus_registry_dir):
     """Create and configure a Korp app instance."""
     app = create_app({
         # https://flask.palletsprojects.com/en/2.2.x/config/#TESTING
         "TESTING": True,
+        "CWB_REGISTRY": corpus_registry_dir,
     })
     # print(app.config)
     yield app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+
+"""
+conftest.py
+
+Pytest fixtures for testing the Korp backend as a Flask app.
+"""
+
+
+import pytest
+
+from korp import create_app
+
+
+@pytest.fixture()
+def app():
+    """Create and configure a Korp app instance."""
+    app = create_app()
+    # https://flask.palletsprojects.com/en/2.2.x/config/#TESTING
+    app.config["TESTING"] = True
+    yield app
+
+
+@pytest.fixture()
+def client(app):
+    """Create and return a test client."""
+    return app.test_client()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,9 +14,11 @@ from korp import create_app
 @pytest.fixture()
 def app():
     """Create and configure a Korp app instance."""
-    app = create_app()
-    # https://flask.palletsprojects.com/en/2.2.x/config/#TESTING
-    app.config["TESTING"] = True
+    app = create_app({
+        # https://flask.palletsprojects.com/en/2.2.x/config/#TESTING
+        "TESTING": True,
+    })
+    # print(app.config)
     yield app
 
 

--- a/tests/corpusutils.py
+++ b/tests/corpusutils.py
@@ -54,6 +54,7 @@ class CWBEncoder:
         """Encode vrt_file with corpus_id."""
         self.encode_vrt_file(corpus_id, vrt_file)
         self.cwb_make(corpus_id)
+        self.copy_info_file(corpus_id, vrt_file)
 
     def encode_vrt_file(self, corpus_id, vrt_file):
         """Run cwb-encode for vrt_file for corpus_id."""
@@ -115,3 +116,14 @@ class CWBEncoder:
             "-r", self._registrydir,
             corpus_id
         ]).check_returncode()
+
+    def copy_info_file(self, corpus_id, vrt_file):
+        """Copy corpus.info from source dir to the corpus data dir as .info."""
+        info_file = os.path.splitext(vrt_file)[0] + ".info"
+        if os.path.isfile(info_file):
+            subprocess.run([
+                "cp",
+                "-p",
+                info_file,
+                os.path.join(self._datarootdir, corpus_id, ".info")
+            ])

--- a/tests/corpusutils.py
+++ b/tests/corpusutils.py
@@ -1,0 +1,117 @@
+
+"""
+tests/corpusutils.py
+
+Utility functions used in pytest tests for Korp, in particular for
+setting up CWB corpus data.
+"""
+
+
+import glob
+import os
+import os.path
+import subprocess
+
+from itertools import chain, zip_longest
+
+
+class CWBEncoder:
+
+    """Encode VRT data to a CWB corpus."""
+
+    # Default positional attribute names if none specified in input
+    _default_pos_attrs = [
+        "word",
+        "lemma",
+        "pos",
+        "msd",
+        "deprel",
+        "dephead",
+        "ref",
+        "lex/",
+    ]
+
+    def __init__(self, corpus_root, cwb_encode=None, cwb_make=None):
+        """Initialize with paths for corpus root, cwb-encode, cwb-make."""
+        cwb_encode = cwb_encode or "cwb-encode"
+        cwb_make = cwb_make or "cwb-make"
+        corpus_root = os.path.abspath(corpus_root)
+        self._datarootdir = os.path.join(corpus_root, "data")
+        self._registrydir = os.path.join(corpus_root, "registry")
+        os.makedirs(self._datarootdir)
+        os.makedirs(self._registrydir)
+
+    def encode_corpora(self, corpus_src_dir):
+        """Encode all VRT data in corpus_src_dir, base name as corpus id."""
+        corpus_ids = []
+        for vrt_file in glob.glob(os.path.join(corpus_src_dir, "*.vrt")):
+            corpus_id = os.path.splitext(os.path.basename(vrt_file))[0]
+            self.encode_corpus(corpus_id, vrt_file)
+            corpus_ids.append(corpus_id)
+        return corpus_ids
+
+    def encode_corpus(self, corpus_id, vrt_file):
+        """Encode vrt_file with corpus_id."""
+        self.encode_vrt_file(corpus_id, vrt_file)
+        self.cwb_make(corpus_id)
+
+    def encode_vrt_file(self, corpus_id, vrt_file):
+        """Run cwb-encode for vrt_file for corpus_id."""
+
+        def interleave(s, seq):
+            """Return [s, seq[0], s, seq[1], ... , s, seq[-1]."""
+            return [*chain(*zip_longest([], seq, fillvalue=s))]
+
+        attrs = self._get_attrs(vrt_file)
+        datadir = os.path.join(self._datarootdir, corpus_id)
+        os.makedirs(datadir)
+        subprocess.run([
+            "cwb-encode",
+            "-f", vrt_file,
+            "-d", datadir,
+            "-R", os.path.join(self._registrydir, corpus_id),
+            "-xsB",
+            "-c", "utf8",
+            "-p", "-",
+            *interleave("-P", attrs["positional"]),
+            *interleave("-S", attrs["structural"])
+        ]).check_returncode()
+
+    def _get_attrs(self, vrt_file):
+        """Get the positional and strucutral attribute info from vrt_file.
+
+        Assumes that vrt_file contains comments of the following kind
+        before the first token line:
+        <!-- #vrt positional-attributes: attr1 attr2 ... -->
+        <!-- #vrt structural-attributes: text:0+a1+a2 sentence:0+a3+a4 ... -->
+        Returns dict
+        {
+            "positional": ["attr1", "attr2", ...],
+            "structural": ["text:0+a1+a2", "sentence:0+a3+a4", ...]
+        }
+        """
+        attrs = {
+            "positional": [],
+            "structural": [],
+        }
+        with open(vrt_file, "r") as vrtf:
+            for line in vrtf:
+                if not line.startswith("<"):
+                    if not attrs["positional"]:
+                        pos_attr_count = line.count("\t") + 1
+                        attrs["positional"] = (
+                            self._default_pos_attrs[:pos_attr_count])
+                    return attrs
+                elif (line.startswith("<!-- #vrt positional-attributes:") or
+                      line.startswith("<!-- #vrt structural-attributes:")):
+                    attrs[line.split()[2].split("-")[0]] = (
+                        line.partition(":")[2].strip(" ->\n").split())
+        return attrs
+
+    def cwb_make(self, corpus_id):
+        """Run cwb-make for corpus corpus_id."""
+        subprocess.run([
+            "cwb-make",
+            "-r", self._registrydir,
+            corpus_id
+        ]).check_returncode()

--- a/tests/data/corpora/src/testcorpus.info
+++ b/tests/data/corpora/src/testcorpus.info
@@ -1,0 +1,2 @@
+Sentences: 2
+Updated: 2023-01-20

--- a/tests/data/corpora/src/testcorpus.vrt
+++ b/tests/data/corpora/src/testcorpus.vrt
@@ -1,0 +1,17 @@
+<!-- #vrt positional-attributes: word lemma -->
+<!-- #vrt structural-attributes: text:0+id paragraph:0+id sentence:0+id -->
+<text id="t1">
+<paragraph id="p1">
+<sentence id="s1">
+</sentence>
+This	this
+is	be
+a	a
+test	test
+.	.
+<sentence id="s2">
+Great	great
+!	!
+</sentence>
+</paragraph>
+</text>

--- a/tests/functional/test_info.py
+++ b/tests/functional/test_info.py
@@ -35,7 +35,7 @@ class TestCorpusInfo:
         assert response.status_code == 200
         assert response.is_json == True
         data = response.get_json()
-        print(data)
+        # print(data)
         corpus_data = data["corpora"][corpus]
         attrs = corpus_data["attrs"]
         # TODO: Add more specific assertions and perhaps split this

--- a/tests/functional/test_info.py
+++ b/tests/functional/test_info.py
@@ -6,16 +6,16 @@ Pytest tests for the Korp /info and /corpus_info endpoints.
 """
 
 
+from tests.testutils import get_response_json
+
+
 class TestInfo:
 
     """Tests for the /info endpoint"""
 
     def test_info_contains_version(self, client):
         """Test that /info response contains version info."""
-        response = client.get("/info")
-        assert response.status_code == 200
-        assert response.is_json == True
-        data = response.get_json()
+        data = get_response_json(client, "/info")
         assert data["version"] and data["version"] != ""
 
 
@@ -26,15 +26,12 @@ class TestCorpusInfo:
     def test_corpus_info_single_corpus(self, client, corpora):
         """Test /corpus_info for a single corpus."""
         corpus = corpora[0].upper()
-        response = client.get(
-            "/corpus_info",
+        data = get_response_json(
+            client, "/corpus_info",
             query_string={
                 "cache": "false",
                 "corpus": corpus,
             })
-        assert response.status_code == 200
-        assert response.is_json == True
-        data = response.get_json()
         # print(data)
         corpus_data = data["corpora"][corpus]
         attrs = corpus_data["attrs"]

--- a/tests/functional/test_info.py
+++ b/tests/functional/test_info.py
@@ -1,0 +1,19 @@
+
+"""
+test_info.py
+
+Pytest tests for the Korp /info endpoint.
+"""
+
+
+class TestInfo:
+
+    """Tests for the /info endpoint"""
+
+    def test_info_contains_version(self, client):
+        """Test that /info response contains version info."""
+        response = client.get("/info")
+        assert response.status_code == 200
+        assert response.is_json == True
+        data = response.get_json()
+        assert data["version"] and data["version"] != ""

--- a/tests/functional/test_info.py
+++ b/tests/functional/test_info.py
@@ -2,7 +2,7 @@
 """
 test_info.py
 
-Pytest tests for the Korp /info endpoint.
+Pytest tests for the Korp /info and /corpus_info endpoints.
 """
 
 
@@ -17,3 +17,31 @@ class TestInfo:
         assert response.is_json == True
         data = response.get_json()
         assert data["version"] and data["version"] != ""
+
+
+class TestCorpusInfo:
+
+    """Tests for the /corpus_info endpoint"""
+
+    def test_corpus_info_single_corpus(self, client, corpora):
+        """Test /corpus_info for a single corpus."""
+        corpus = corpora[0].upper()
+        response = client.get(
+            "/corpus_info",
+            query_string={
+                "cache": "false",
+                "corpus": corpus,
+            })
+        assert response.status_code == 200
+        assert response.is_json == True
+        data = response.get_json()
+        print(data)
+        corpus_data = data["corpora"][corpus]
+        attrs = corpus_data["attrs"]
+        # TODO: Add more specific assertions and perhaps split this
+        # into multiple tests
+        assert attrs
+        assert attrs["p"]
+        assert attrs["s"]
+        assert data["total_size"]
+        assert data["total_sentences"]

--- a/tests/functional/test_query.py
+++ b/tests/functional/test_query.py
@@ -6,22 +6,22 @@ Pytest tests for the Korp /query endpoint
 """
 
 
+from tests.testutils import get_response_json
+
+
 class TestQuery:
 
     """Tests for /query"""
 
     def test_query_single_corpus(self, client, corpora):
         """Test a simple query on a single corpus."""
-        response = client.get(
-            "/query",
+        data = get_response_json(
+            client, "/query",
             query_string={
                 "corpus": "testcorpus",
                 "cqp": "[lemma=\"this\"]",
                 "cache": "false",
             })
-        assert response.status_code == 200
-        assert response.is_json == True
-        data = response.get_json()
         kwic = data["kwic"]
         assert len(kwic) == data["hits"]
         # print(data)

--- a/tests/functional/test_query.py
+++ b/tests/functional/test_query.py
@@ -1,0 +1,28 @@
+
+"""
+test_query.py
+
+Pytest tests for the Korp /query endpoint
+"""
+
+
+class TestQuery:
+
+    """Tests for /query"""
+
+    def test_query_single_corpus(self, client, corpora):
+        """Test a simple query on a single corpus."""
+        response = client.get(
+            "/query",
+            query_string={
+                "corpus": "testcorpus",
+                "cqp": "[lemma=\"this\"]",
+                "cache": "false",
+            })
+        assert response.status_code == 200
+        assert response.is_json == True
+        data = response.get_json()
+        kwic = data["kwic"]
+        assert len(kwic) == data["hits"]
+        print(data)
+        # assert 0

--- a/tests/functional/test_query.py
+++ b/tests/functional/test_query.py
@@ -24,5 +24,5 @@ class TestQuery:
         data = response.get_json()
         kwic = data["kwic"]
         assert len(kwic) == data["hits"]
-        print(data)
+        # print(data)
         # assert 0

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -1,0 +1,17 @@
+
+"""
+tests.testutils
+
+Utility functions that can be called from tests. The functions may
+contain assertions that are subject to rewriting.
+"""
+
+
+def get_response_json(client, *args, **kwargs):
+    """Call client.get with given args, assert success, return response JSON."""
+    # This function helps in making actual test functions for
+    # endpoints slightly more compact and less repetitive
+    response = client.get(*args, **kwargs)
+    assert response.status_code == 200
+    assert response.is_json
+    return response.get_json()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,38 @@
+
+"""
+test_utils.py
+
+Unit tests for functions in module korp.utils.
+"""
+
+
+from korp import utils
+
+
+class TestParseCorpora:
+
+    """Tests for parse_corpora"""
+
+    def test_parse_corpora_empty(self):
+        assert utils.parse_corpora({}) == []
+
+    def test_parse_corpora_empty_string(self):
+        assert utils.parse_corpora({"corpus": ""}) == [""]
+
+    def test_parse_corpora_list(self):
+        assert utils.parse_corpora({"corpus": ["A", "B"]}) == ["A", "B"]
+
+    def test_parse_corpora_string(self):
+        assert utils.parse_corpora(
+            {"corpus": utils.QUERY_DELIM.join(["A", "B"])}) == ["A", "B"]
+
+    def test_parse_corpora_string_upper(self):
+        assert utils.parse_corpora(
+            {"corpus": utils.QUERY_DELIM.join(["a", "b"])}) == ["A", "B"]
+
+    def test_parse_corpora_sort(self):
+        assert utils.parse_corpora({"corpus": ["B", "A"]}) == ["A", "B"]
+
+    def test_parse_corpora_unique(self):
+        assert (utils.parse_corpora({"corpus": ["A", "B", "A", "B"]}) ==
+                ["A", "B"])


### PR DESCRIPTION
This pull request contains support for implementing Pytest tests for the Korp backend, along with a couple of sample tests.


## Main features

The main features of the pull request are listed below. Please see [`tests/README.md`](https://github.com/CSCfi/Kielipankki-korp-backend/blob/t-pytest-tests/tests/README.md) for some more documentation on how to run and write tests.

1. Dicrectory [`tests`](https://github.com/CSCfi/Kielipankki-korp-backend/tree/t-pytest-tests/tests) contains a couple of **sample tests** and some supporting code. Tests have been divided into **functional and unit tests** (with subdirectories named correspondingly): functional tests test endpoints as seen by the user, whereas unit tests test individual functions.

2. To allow **overriding configuration settings** for testing purposes, the parameter `config_override` was added to `korp.create_app`.

3. [`tests/conftest.py`](https://github.com/CSCfi/Kielipankki-korp-backend/blob/t-pytest-tests/tests/conftest.py) contains a couple of **fixtures** that should make it easier to setup commonly-used test prerequisites, such as corpus data and a test client. More fixtures can be added as deemed useful.

4. **Requirements for testing** are in [`requirements-dev.txt`](https://github.com/CSCfi/Kielipankki-korp-backend/blob/t-pytest-tests/requirements-dev.txt), as advised by @aajarven.

5. The (functional) tests can use **CWB corpus data**, which is encoded for each test session **from corpus source files** in [`tests/data/corpora/src`](https://github.com/CSCfi/Kielipankki-korp-backend/tree/t-pytest-tests/tests/data/corpora/src), as I thought it would make the tests more transparent than using pre-encoded corpus data. It would not seem to be significantly slower if the test corpora are relatively few and small. Encoding the corpus data requires `cwb-encode` and `cwb-make`.

   The **corpus data is represented as VRT** (VeRticalized Text), the CWB input format, one file per CWB corpus. To make the file more self-contained and to simplify encoding, I opted for listing both positional and structural attributes in the VRT file as comments at the beginning of the file; for example:

    ```
    <!-- #vrt positional-attributes: word lemma -->
    <!-- #vrt structural-attributes: text:0+id paragraph:0+id sentence:0+id -->
    ```

   If you have suggestions for a better approach for specifying the attribute information (or the whole corpus data), please tell us. It would also be possible to support alternative approaches.

   In addition to the actual corpus data, a corpus needs to have an `.info` file. As a future improvement, the information in the `.info` file could be computed based on the VRT file if it does not exist.


## Open questions

At least the following questions are open:

1. **How to test endpoints that use the MySQL database?** Should we have a real database, populated for each test session, or should we only mock database access? I think for some tests, a real database would be better. @aajarven mentioned [`testing.mysqld`](https://pypi.org/project/testing.mysqld/) but recommended that we should also investigate other options.

2. **How to test plugins?** Plugin code and tests may be in another repository but I think plugin tests should be able to access fixtures and test corpora.

3. **Would it be possible to automate testing with GitHub** (or with some other test automation service)? Otherwise perhaps yes, but what about the requirement of having CWB installed?

4. **How to organize tests in a good way?** Maybe some requests could be made fixtures in the individual test modules, so that it would be easier and less repetitive to test different properties of the result in separate tests. I extracted a common pattern of making a request, asserting its success and getting the JSON result to a function in [`tests/testutils.py`](https://github.com/CSCfi/Kielipankki-korp-backend/blob/t-pytest-tests/tests/testutils.py).


## General comments

I think it made implementing testing easier that the code had been split into modules.

We intend to rebase the branches containing our modifications on this branch, so that we can provide some tests for the modifications for which we make pull requests. However, we do not promise comprehensive tests up front.