### PR TITLE
Allow configuring database character set

### DIFF
--- a/config.py
+++ b/config.py
@@ -34,6 +34,9 @@ DBPORT = 3306
 # Database name
 DBNAME = ""
 
+# Database character set (use "utf8mb4" for full Unicode)
+DBCHARSET = "utf8"
+
 # Word Picture table prefix
 DBWPTABLE = "relations"
 

--- a/korp/__init__.py
+++ b/korp/__init__.py
@@ -50,6 +50,7 @@ def create_app(config_override=None):
         MYSQL_PASSWORD=app.config["DBPASSWORD"],
         MYSQL_DB=app.config["DBNAME"],
         MYSQL_PORT=app.config["DBPORT"],
+        MYSQL_CHARSET=app.config["DBCHARSET"],
         MYSQL_USE_UNICODE=True,
         MYSQL_CURSORCLASS="DictCursor",
     )


### PR DESCRIPTION
**What**

Add configuration variable `DBCHARSET` for configuring the MySQL database character set. The default value is `"utf8"`, which is the previously implicitly used default in `flask_mysqldb`.

**Why**

In MySQL and MariaDB, the default character set `utf8` does not support Unicode characters encoded as four bytes in UTF-8 (code points above U+FFFF); instead, you need to use `utf8mb4` (as we do). This may have changed in recent versions of MySQL and MariaDB but at least MariaDB 10.11.13 works like this.

If the database character set is `utf8mb4` and the code tries to read it as `utf8`, reading data with a code point above U+FFFF causes `OperationalError` (1267, "Illegal mix of collations (utf8mb4\_bin,IMPLICIT) and (utf8mb3\_general\_ci,COERCIBLE) for operation '='").

**Note**

I noticed that the testing code already refers to the `DBCHARSET` configuration variable and the tests accessing the database do not work without it. I apologize for that.