### PR TITLE
Tests: Fix to always read the default Korp configuration

### DIFF
--- a/tests/configutils.py
+++ b/tests/configutils.py
@@ -7,17 +7,30 @@ handling the Korp configuration.
 """
 
 
-def get_korp_config():
-    """Return the Korp configuration as a dict.
+from importlib import import_module
+from pathlib import Path
 
-    Return the Korp configuration fron module instance.config, or if
-    that is not available, from module config.
+from flask.config import Config
+
+
+def get_korp_config():
+    """Return the Korp configuration as a `flask.config.Config` object.
+
+    Return the Korp configuration from module `instance.config`, with
+    defaults from module `config` for variables not defined in
+    `instance.config`.
+
+    Note that this assumes that the instance configuration file is the
+    default one (`"{root_path}/instance/config.py"`).
     """
-    try:
-        from instance import config
-    except ImportError:
-        import config
-    # Treat all uppercase items in the config module as configuration
-    # variables and add them to the dict to return
-    return dict((key, val) for key, val in config.__dict__.items()
-                if key.isupper())
+    # Find Korp package root based on the location of the config
+    # module
+    korp_dir = Path(import_module("config").__file__).parent
+    conf = Config(str(korp_dir))
+    # Load the default configuration
+    conf.from_object("config")
+    # Try to load the instance configuration
+    instance_config_path = korp_dir / 'instance' / 'config.py'
+    if instance_config_path.is_file():
+        conf.from_pyfile(str(instance_config_path))
+    return conf


### PR DESCRIPTION
**What**

1. Fix [`get_korp_config`](https://github.com/CSCfi/Kielipankki-korp-backend/blob/b02b91834c705a4ef7a1f10dcd75ef26fd8518f5/tests/configutils.py#L16-L36) in `tests/configutils.py` to always read the default Korp configuration, before reading the instance configuration.
2. Make `get_korp_config` return a `flask.config.Config` object and use its methods to read the configuration files, similarly to the Korp app code, instead of importing them as modules and returning a `dict`.

**Why**

The changes should make the tests read the Korp configuration in the same way as the Korp app itself does. The returned configuration object is now also of the same type.

Previously the default Korp configuration was read only if the instance configuration was missing, so configuration variables not defined in the instance configuration were left undefined. (I had overlooked the fact that the Korp app reads the default configuration even when an instance configuration exists.)